### PR TITLE
[BUG] deploy.sh timeout

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -14,5 +14,5 @@ permission:
 hooks:
   ApplicationStart:
     - location: deploy.sh
-      timeout: 60
+      timeout: 120
       runas: ubuntu


### PR DESCRIPTION
## 📋 이슈 번호
- close #111 

## 🛠 구현 사항
-  CodeDeploy 설정에서 타임아웃 시간을 늘려 스크립트가 더 많은 시간을 가질 수 있도록 조정했습니다.

## 📚 변경 사항
- appspec.yml
